### PR TITLE
Fixed switch not updating state immediately

### DIFF
--- a/custom_components/audioflow/switch.py
+++ b/custom_components/audioflow/switch.py
@@ -97,13 +97,13 @@ class ZoneEnabledSwitch(ZoneEntity, SwitchEntity):
         await self.coordinator.client.set_zone_config(
             self.zone_id, enabled=True, zone_name=self.af_zone["name"]
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.client.set_zone_config(
             self.zone_id, enabled=False, zone_name=self.af_zone["name"]
         )
-        await self.coordinator.async_request_refresh()
+        await self.coordinator.async_refresh()
 
     @property
     def name(self) -> str | None:

--- a/custom_components/audioflow/switch.py
+++ b/custom_components/audioflow/switch.py
@@ -69,11 +69,11 @@ class ZoneStateSwitch(ZoneEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.coordinator.client.set_zone_state(self.zone_id, True)
-        await coordinator.async_refresh()
+        await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.client.set_zone_state(self.zone_id, False)
-        await coordinator.async_refresh()
+        await self.coordinator.async_refresh()
 
     @property
     def name(self) -> str:

--- a/custom_components/audioflow/switch.py
+++ b/custom_components/audioflow/switch.py
@@ -69,11 +69,11 @@ class ZoneStateSwitch(ZoneEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.coordinator.client.set_zone_state(self.zone_id, True)
-        await self.coordinator.async_request_refresh()
+        await coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.client.set_zone_state(self.zone_id, False)
-        await self.coordinator.async_request_refresh()
+        await coordinator.async_refresh()
 
     @property
     def name(self) -> str:


### PR DESCRIPTION
This change fixes an issue where turning on/off a zone would take sometimes a few seconds for the UI to update in HomeAssistant. This seems to be due to the coordinator deduping requests and waiting a few seconds before actually triggering the refresh. By using `async_refresh()` instead of `async_request_refresh()`, it causes the zones endpoint to be called immediately which then updates the state. 

Fixes #5 
